### PR TITLE
Add check on empty result in user & role resource read.

### DIFF
--- a/neo4j/resource_role.go
+++ b/neo4j/resource_role.go
@@ -62,6 +62,10 @@ func resourceRoleRead(ctx context.Context, d *schema.ResourceData, m interface{}
 	defer session.Close()
 	result, err := neo4j.Single(session.Run("SHOW ROLES WHERE role = $role", map[string]interface{}{"role": d.Id()}))
 	if err != nil {
+		if err.Error() == "Result contains no more records" {
+			d.SetId("")
+			return diags
+		}
 		return diag.FromErr(err)
 	}
 	name, _ := result.Get("role")

--- a/neo4j/resource_user.go
+++ b/neo4j/resource_user.go
@@ -96,6 +96,10 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, m interface{}
 	defer session.Close()
 	result, err := neo4j.Single(session.Run("SHOW USERS YIELD user WHERE user = $username", map[string]interface{}{"username": d.Id()}))
 	if err != nil {
+		if err.Error() == "Result contains no more records" {
+			d.SetId("")
+			return diags
+		}
 		return diag.FromErr(err)
 	}
 	name, _ := result.Get("user")


### PR DESCRIPTION
@headyj, This enables correct handling in case the user / role was deleted outside TF
Found this in another testing iteration 